### PR TITLE
Build with release profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-# -*- sh -*-
 FROM geal/archlinux-rust
 MAINTAINER Geoffroy Couprie, contact@geoffroycouprie.com
-
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
 ADD . /source
 WORKDIR /source
 
 EXPOSE 8080
 RUN rustc -V
-RUN cargo build
-CMD cargo run
+
+RUN cargo build --release
+CMD cargo run --release


### PR DESCRIPTION
Since Rust developers usually have the Rust toolchain already installed, Docker is mostly used for deployment. In this case, it makes sense to build the app in release mode, with optimizations enabled.

Minor change: `LD_LIBRARY_PATH` is already correctly set within the base image (geal/archlinux-rust), we don't need to redefine it here.
